### PR TITLE
ci: use release bot for Swift publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,16 +68,27 @@ jobs:
       - verify
     runs-on: macos-26
     timeout-minutes: 30
+    environment: release
     permissions:
       contents: write
       issues: write
       pull-requests: write
 
     steps:
+      - name: Create release bot token
+        id: release-bot
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ vars.PUTIO_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.PUTIO_RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
       - name: Check out repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.release-bot.outputs.token }}
 
       - name: Select latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -122,9 +133,9 @@ jobs:
             @semantic-release/git
             conventional-changelog-conventionalcommits
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-          GIT_AUTHOR_NAME: devsputio
-          GIT_AUTHOR_EMAIL: devs@put.io
-          GIT_COMMITTER_NAME: devsputio
-          GIT_COMMITTER_EMAIL: devs@put.io
+          GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
+          GIT_AUTHOR_EMAIL: ${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
+          GIT_COMMITTER_EMAIL: ${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - The Swift Package module, CocoaPods module, and public SDK types are all `PutioSDK`
 - CI and release automation run from `main`
 - The release workflow uses semantic-release after `make verify` passes on `main`
-- GitHub release writes use `putio-release-bot`; CocoaPods publishing additionally needs `COCOAPODS_TRUNK_TOKEN`
+- GitHub release writes use `putio-release-bot`; CocoaPods publishing additionally needs `COCOAPODS_TRUNK_TOKEN` in the protected `release` Environment
 - Verify example workspace installation when auth-flow or package-install surface changes
 - Repo verification should build the Swift package and the `PutioSDK` CocoaPods scheme from the example workspace
 - `make verify` prefers an Xcode-advertised iPhone simulator destination on iOS `26.0+` and falls back to the installed `iphonesimulator` SDK when Xcode is not exposing one yet

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 - The Swift Package module, CocoaPods module, and public SDK types are all `PutioSDK`
 - CI and release automation run from `main`
 - The release workflow uses semantic-release after `make verify` passes on `main`
-- GitHub releases need only the built-in `GITHUB_TOKEN`; CocoaPods publishing additionally needs `COCOAPODS_TRUNK_TOKEN`
+- GitHub release writes use `putio-release-bot`; CocoaPods publishing additionally needs `COCOAPODS_TRUNK_TOKEN`
 - Verify example workspace installation when auth-flow or package-install surface changes
 - Repo verification should build the Swift package and the `PutioSDK` CocoaPods scheme from the example workspace
 - `make verify` prefers an Xcode-advertised iPhone simulator destination on iOS `26.0+` and falls back to the installed `iphonesimulator` SDK when Xcode is not exposing one yet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,8 @@ make print-simulator-destination
 - Do not commit tokens, private API credentials, or release-only secrets
 - The release workflow uses semantic-release on `main`
 - Conventional commits drive automated version selection through semantic-release
-- GitHub releases only need the built-in `GITHUB_TOKEN`; CocoaPods publishing additionally needs `COCOAPODS_TRUNK_TOKEN`
+- GitHub release writes use `putio-release-bot` through `PUTIO_RELEASE_BOT_APP_ID` and `PUTIO_RELEASE_BOT_PRIVATE_KEY` in the protected `release` Environment
+- CocoaPods publishing additionally needs `COCOAPODS_TRUNK_TOKEN`
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ make print-simulator-destination
 - The release workflow uses semantic-release on `main`
 - Conventional commits drive automated version selection through semantic-release
 - GitHub release writes use `putio-release-bot` through `PUTIO_RELEASE_BOT_APP_ID` and `PUTIO_RELEASE_BOT_PRIVATE_KEY` in the protected `release` Environment
-- CocoaPods publishing additionally needs `COCOAPODS_TRUNK_TOKEN`
+- CocoaPods publishing additionally needs `COCOAPODS_TRUNK_TOKEN` in the protected `release` Environment
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary

Use `putio-release-bot` for Swift SDK release GitHub writes instead of the default `GITHUB_TOKEN` or human/team commit metadata.

## Changed

- release workflow mints a pinned `actions/create-github-app-token` token from the protected `release` Environment
- checkout and semantic-release use the app installation token for GitHub release writes
- release commit metadata now matches the app bot actor
- agent/contributor docs name the release bot credentials and CocoaPods token boundary

## Risks

- The `release` Environment must provide `PUTIO_RELEASE_BOT_APP_ID`, `PUTIO_RELEASE_BOT_PRIVATE_KEY`, and `COCOAPODS_TRUNK_TOKEN` for a publishing run.
- The bot app must stay installed on this repo and allowed by branch/tag protection.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`

## Complexity

Neutral. The workflow keeps the existing semantic-release path and swaps the GitHub write identity to the dedicated release app.
